### PR TITLE
Correção para a função get_all_apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/.idea
+/.vscode
 /target
 /example/target
 .envrc/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
 name = "discloud-rs"
-version = "0.2.0-alpha"
-authors = ["jackskelt"]
+version = "0.2.1-alpha"
+authors = ["jackskelt", "Nathan Miguel"]
 description = "A rust wrapper for Discloud's API"
 repository = "https://github.com/jackskelt/discloud-rs"
 license = "Apache-2.0"
 keywords = ["discloud", "hosting", "api", "wrapper"]
 categories = ["api-bindings"]
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.120"
+serde_json = "1.0"
 tracing = "0.1"
 
 [dev-dependencies]
-tokio = { version = "1.36", features = ["macros", "rt-multi-thread"] }
-tracing-subscriber = "0.3.18"
-dotenvy = "0.15.7"
+tokio = { version = "1.47", features = ["macros", "rt-multi-thread"] }
+tracing-subscriber = "0.3"
+dotenvy = "0.15"

--- a/src/app.rs
+++ b/src/app.rs
@@ -35,8 +35,7 @@ pub struct App {
     pub auto_restart: bool,
     #[serde(rename = "avatarURL")]
     pub avatar_url: String,
-    #[serde(rename = "exitCode")]
-    pub exit_code: i32,
+    pub exit_code: Option<i32>,
     pub id: String,
     pub lang: String,
     pub main_file: String,

--- a/src/app.rs
+++ b/src/app.rs
@@ -35,6 +35,7 @@ pub struct App {
     pub auto_restart: bool,
     #[serde(rename = "avatarURL")]
     pub avatar_url: String,
+    #[serde(rename = "exitCode")]
     pub exit_code: i32,
     pub id: String,
     pub lang: String,


### PR DESCRIPTION
Mudanças: Adicionado Option ao campo `exit_code` da struct `App`.

Aparentemente, o campo `exit_code` nao existie ao usar a rota `/app/all` e eu nao sei se isso pode ser um bug da API. Caso seja usada a mesma rota, porém, com o `id`, o campo  `exit_code` é passado normalmente.